### PR TITLE
ResetMetrics for metrics.go

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -141,3 +141,19 @@ func (met *metrics) Dump() ([]byte, error) {
 	met.UpdateSystemMetrics()
 	return json.Marshal(Metric.store)
 }
+
+// ResetMetrics resets all registered key values to 0 expect for System Metrics.
+// This locks all writes in the process.
+func (met *metrics) ResetMetrics() {
+	met.mutex.Lock()
+	defer met.mutex.Unlock()
+
+	for key, _ := range met.store {
+		switch key {
+		case MetricProcessStart, MetricGoRoutines:
+			// ignore
+		default:
+			met.store[key] = new(int64)
+		}
+	}
+}

--- a/metric_test.go
+++ b/metric_test.go
@@ -108,3 +108,19 @@ func TestMetricsIncDec(t *testing.T) {
 	expect.Equal(int64(0), count)
 
 }
+
+func TestMetricsReset(t *testing.T) {
+	expect := ttesting.NewExpect(t)
+	mockMetric := getMockMetric()
+	mockMetric.New("MockMetric")
+
+	mockMetric.Set("MockMetric", int64(10))
+	count, err := mockMetric.Get("MockMetric")
+	expect.Nil(err)
+	expect.Equal(int64(10), count)
+
+	mockMetric.ResetMetrics()
+	count, err = mockMetric.Get("MockMetric")
+	expect.Nil(err)
+	expect.Equal(int64(0), count)
+}


### PR DESCRIPTION
Enabled to reset user added metrics in metrics.go. This makes it possible to generate differential values out of stats if needed be. 